### PR TITLE
Add unit tests for more problems

### DIFF
--- a/Tests/P1071_Greatest_Common_Divisor_of_Strings_Tests.cs
+++ b/Tests/P1071_Greatest_Common_Divisor_of_Strings_Tests.cs
@@ -1,0 +1,18 @@
+using Problems;
+
+namespace Tests;
+
+public class P1071_Greatest_Common_Divisor_of_Strings_Tests
+{
+    [Theory]
+    [InlineData("ABCABC", "ABC", "ABC")]
+    [InlineData("ABABAB", "ABAB", "AB")]
+    [InlineData("LEET", "CODE", "")]
+    [InlineData("A", "A", "A")]
+    public void GcdOfStringsBruteForce_ReturnsExpected(string str1, string str2, string expected)
+    {
+        var gcd = new P1071_Greatest_Common_Divisor_of_Strings();
+        var result = gcd.GcdOfStringsBruteForce(str1, str2);
+        Assert.Equal(expected, result);
+    }
+}

--- a/Tests/P1089_Duplicate_Zeros_Tests.cs
+++ b/Tests/P1089_Duplicate_Zeros_Tests.cs
@@ -1,0 +1,30 @@
+using Problems;
+
+namespace Tests;
+
+public class P1089_Duplicate_Zeros_Tests
+{
+    [Theory]
+    [InlineData(new int[] {1,0,2,3,0,4,5,0}, new int[] {1,0,0,2,3,0,0,4})]
+    [InlineData(new int[] {1,2,3}, new int[] {1,2,3})]
+    [InlineData(new int[] {0,0,0,0,0}, new int[] {0,0,0,0,0})]
+    public void DuplicateZeros_TwoPointerBackward_Works(int[] input, int[] expected)
+    {
+        var sol = new P1089_Duplicate_Zeros();
+        var arr = (int[])input.Clone();
+        sol.DuplicateZeros_TwoPointerBackward(arr);
+        Assert.Equal(expected, arr);
+    }
+
+    [Theory]
+    [InlineData(new int[] {1,0,2,3,0,4,5,0}, new int[] {1,0,0,2,3,0,0,4})]
+    [InlineData(new int[] {1,2,3}, new int[] {1,2,3})]
+    [InlineData(new int[] {0,0,0,0,0}, new int[] {0,0,0,0,0})]
+    public void DuplicateZeros_ShiftOnZero_Works(int[] input, int[] expected)
+    {
+        var sol = new P1089_Duplicate_Zeros();
+        var arr = (int[])input.Clone();
+        sol.DuplicateZeros_ShiftOnZero(arr);
+        Assert.Equal(expected, arr);
+    }
+}

--- a/Tests/P1295_Find_Numbers_with_Even_Number_of_Digits_Tests.cs
+++ b/Tests/P1295_Find_Numbers_with_Even_Number_of_Digits_Tests.cs
@@ -1,0 +1,19 @@
+using Problems;
+
+namespace Tests;
+
+public class P1295_Find_Numbers_with_Even_Number_of_Digits_Tests
+{
+    [Theory]
+    [InlineData(new[] {12,345,2,6,7896}, 2)]
+    [InlineData(new[] {555,901,482,1771}, 1)]
+    [InlineData(new[] {1,2,3,4}, 0)]
+    public void FindNumbers_AllImplementations_ReturnSame(int[] nums, int expected)
+    {
+        var solver = new P1295_Find_Numbers_with_Even_Number_of_Digits();
+        Assert.Equal(expected, solver.FindNumbers_Range(nums));
+        Assert.Equal(expected, solver.FindNumbers_Log10(nums));
+        Assert.Equal(expected, solver.FindNumbers_String(nums));
+        Assert.Equal(expected, solver.FindNumbers_Divide(nums));
+    }
+}

--- a/Tests/P1431_Kids_With_the_Greatest_Number_of_Candies_Tests.cs
+++ b/Tests/P1431_Kids_With_the_Greatest_Number_of_Candies_Tests.cs
@@ -1,0 +1,18 @@
+using System.Linq;
+using Problems;
+
+namespace Tests;
+
+public class P1431_Kids_With_the_Greatest_Number_of_Candies_Tests
+{
+    [Theory]
+    [InlineData(new[] {2,3,5,1,3}, 3, new[] {true,true,true,false,true})]
+    [InlineData(new[] {4,2,1,1,2}, 1, new[] {true,false,false,false,false})]
+    [InlineData(new[] {12,1,12}, 10, new[] {true,false,true})]
+    public void KidsWithCandies_ReturnsExpected(int[] candies, int extra, bool[] expected)
+    {
+        var solver = new P1431_Kids_With_the_Greatest_Number_of_Candies();
+        var result = solver.KidsWithCandies(candies, extra).ToArray();
+        Assert.Equal(expected, result);
+    }
+}

--- a/Tests/P485_Max_Consecutive_Ones_Tests.cs
+++ b/Tests/P485_Max_Consecutive_Ones_Tests.cs
@@ -1,0 +1,18 @@
+using Problems;
+
+namespace Tests;
+
+public class P485_Max_Consecutive_Ones_Tests
+{
+    [Theory]
+    [InlineData(new[] {1,1,0,1,1,1}, 3)]
+    [InlineData(new[] {1,0,1,1,0,1}, 2)]
+    [InlineData(new[] {0,0,0}, 0)]
+    [InlineData(new[] {1,1,1,1}, 4)]
+    public void FindMaxConsecutiveOnes_MethodsReturnSame(int[] nums, int expected)
+    {
+        var solver = new P485_Max_Consecutive_Ones();
+        Assert.Equal(expected, solver.FindMaxConsecutiveOnesUsingWindow(nums));
+        Assert.Equal(expected, solver.FindMaxConsecutiveOnesLinearScan(nums));
+    }
+}


### PR DESCRIPTION
## Summary
- add tests for Greatest Common Divisor of Strings
- add tests for Duplicate Zeros
- add tests for Find Numbers with Even Number of Digits
- add tests for Kids With the Greatest Number of Candies
- add tests for Max Consecutive Ones

## Testing
- `dotnet test --no-build --verbosity quiet` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6855393c7c48832baf8dc946cd447ee6